### PR TITLE
Generate sourcemap when compiling to Roblox to flatten dependencies

### DIFF
--- a/.darklua-wally.json
+++ b/.darklua-wally.json
@@ -10,7 +10,8 @@
       },
       "target": {
         "name": "roblox",
-        "indexing_style": "wait_for_child"
+        "indexing_style": "wait_for_child",
+        "rojo_sourcemap": "./sourcemap.json"
       }
     },
     "compute_expression",

--- a/modules/boolean/default.project.json
+++ b/modules/boolean/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Boolean",
+  "name": "boolean",
   "tree": {
     "$path": "src"
   }

--- a/modules/boolean/package.json
+++ b/modules/boolean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/boolean",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/collections/default.project.json
+++ b/modules/collections/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Collections",
+  "name": "collections",
   "tree": {
     "$path": "src"
   }

--- a/modules/collections/default.project.json
+++ b/modules/collections/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "Collections",
+  "tree": {
+    "$path": "src"
+  }
+}

--- a/modules/collections/package.json
+++ b/modules/collections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/collections",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/console/default.project.json
+++ b/modules/console/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Console",
+  "name": "console",
   "tree": {
     "$path": "src"
   }

--- a/modules/console/package.json
+++ b/modules/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/console",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/es7-types/default.project.json
+++ b/modules/es7-types/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "ES7Types",
+  "name": "es7-types",
   "tree": {
     "$path": "src"
   }

--- a/modules/es7-types/package.json
+++ b/modules/es7-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/es7-types",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/instance-of/default.project.json
+++ b/modules/instance-of/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "InstanceOf",
+  "name": "instance-of",
   "tree": {
     "$path": "src"
   }

--- a/modules/instance-of/package.json
+++ b/modules/instance-of/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/instance-of",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/luau-polyfill/default.project.json
+++ b/modules/luau-polyfill/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "LuauPolyfill",
+  "name": "luau-polyfill",
   "tree": {
     "$path": "src"
   }

--- a/modules/luau-polyfill/package.json
+++ b/modules/luau-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/luau-polyfill",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/math/default.project.json
+++ b/modules/math/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Math",
+  "name": "math",
   "tree": {
     "$path": "src"
   }

--- a/modules/math/package.json
+++ b/modules/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/math",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/number/default.project.json
+++ b/modules/number/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Number",
+  "name": "number",
   "tree": {
     "$path": "src"
   }

--- a/modules/number/package.json
+++ b/modules/number/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/number",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/string/default.project.json
+++ b/modules/string/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "String",
+  "name": "string",
   "tree": {
     "$path": "src"
   }

--- a/modules/string/package.json
+++ b/modules/string/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/string",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/modules/timers/default.project.json
+++ b/modules/timers/default.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Timers",
+  "name": "timers",
   "tree": {
     "$path": "src"
   }

--- a/modules/timers/package.json
+++ b/modules/timers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsdotlua/timers",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "license": "MIT",
   "main": "src/init.lua",
   "repository": {

--- a/scripts/build-wally-package.sh
+++ b/scripts/build-wally-package.sh
@@ -18,14 +18,19 @@ for module_path in modules/*; do
 
     wally_package=build/wally/$module_name
     roblox_package=roblox/node_modules/@jsdotlua/$module_name
+    original_package=node_modules/@jsdotlua/$module_name
 
     mkdir -p $wally_package
     mkdir -p $wally_package/src
     cp LICENSE $wally_package/LICENSE
-    node ./scripts/npm-to-wally.js $roblox_package/package.json $wally_package/wally.toml --workspace-path modules
+    cp $original_package/default.project.json $wally_package
+    node ./scripts/npm-to-wally.js $roblox_package/package.json $wally_package/wally.toml $roblox_package/wally-package.project.json --workspace-path modules
 
     cp .darklua-wally.json $roblox_package
     cp -r roblox/node_modules/.luau-aliases/* $roblox_package
+
+    rojo sourcemap $roblox_package/wally-package.project.json --output $roblox_package/sourcemap.json
+
     darklua process --config $roblox_package/.darklua-wally.json $roblox_package/src $wally_package/src
 
     wally package --project-path $wally_package --list


### PR DESCRIPTION
The community reported that our wally packages published were not structured as expected. Here's what I did to try to fix this:

- Each package is now published with a `default.project.json` rojo config
- When generating requires for Roblox, I'm using a sourcemap that flatten the dependencies into the package parent instance

### Checklist
  - [x] Bump package versions